### PR TITLE
Add logging to load.sh

### DIFF
--- a/load.sh
+++ b/load.sh
@@ -3,10 +3,35 @@ user=$1;
 pass=$2;
 host=$3;
 port=$4;
-mysql --protocol=tcp -h ${host} -P ${port} -u ${user} -p${pass} < ./sql_files/isanteplusreportsddlscript.sql
-mysql --protocol=tcp -h ${host} -P ${port} -u ${user} -p${pass} < ./sql_files/isanteplusreportsdmlscript.sql
-mysql --protocol=tcp -h ${host} -P ${port} -u ${user} -p${pass} < ./sql_files/drug_lookup_isanteplus.sql
-mysql --protocol=tcp -h ${host} -P ${port} -u ${user} -p${pass} < ./sql_files/run_isante_patient_status.sql
-mysql --protocol=tcp -h ${host} -P ${port} -u ${user} -p${pass} < ./sql_files/insertion_obs_by_day.sql
-mysql --protocol=tcp -h ${host} -P ${port} -u ${user} -p${pass} < ./sql_files/patient_status_arv_dml.sql
-mysql --protocol=tcp -h ${host} -P ${port} -u ${user} -p${pass} < ./sql_files/indicators_report.sql
+
+LOG_DIR="/var/log/isanteplus-etl"
+mkdir -p "${LOG_DIR}" 2>/dev/null
+LOG_FILE="${LOG_DIR}/load-$(date +%Y%m%d-%H%M%S).log"
+
+log() {
+    echo "$(date '+%Y-%m-%d %H:%M:%S') $1" | tee -a "${LOG_FILE}"
+}
+
+run_sql() {
+    local script=$1
+    local name=$(basename "$script")
+    log "Running ${name}..."
+    mysql --protocol=tcp -h ${host} -P ${port} -u ${user} -p${pass} --force --show-warnings -vv < "$script" >>"${LOG_FILE}" 2>&1
+    local exit_code=$?
+    if [ $exit_code -ne 0 ]; then
+        log "ERROR: ${name} failed with exit code ${exit_code}"
+    else
+        log "OK: ${name} completed"
+    fi
+}
+
+log "=== iSantePlus ETL load started ==="
+run_sql ./sql_files/isanteplusreportsddlscript.sql
+run_sql ./sql_files/isanteplusreportsdmlscript.sql
+run_sql ./sql_files/drug_lookup_isanteplus.sql
+run_sql ./sql_files/run_isante_patient_status.sql
+run_sql ./sql_files/insertion_obs_by_day.sql
+run_sql ./sql_files/patient_status_arv_dml.sql
+run_sql ./sql_files/indicators_report.sql
+log "=== iSantePlus ETL load finished ==="
+log "Log file: ${LOG_FILE}"


### PR DESCRIPTION
## Problem

`load.sh` runs 7 SQL scripts via the `mysql` CLI. Errors go to stderr and are lost when the terminal session ends. When a script fails (e.g. missing column, syntax error), there is no record of what happened hence making it impossible to diagnose ETL failures after the fact.

## Fix

Each run now writes a timestamped log file to `/var/log/isanteplus-etl/`:

```
/var/log/isanteplus-etl/load-20260325-150000.log
```

The log captures:
- Start/end timestamps
- Which script is running
- MySQL errors (redirected from stderr)
- Pass/fail status with exit codes

Output also prints to the terminal so the operator sees progress in real time.